### PR TITLE
added support for KDE/Dolphin (copy link only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install: /usr/bin/xclip /usr/share/nautilus-python
 	cp -p owncloud-copy-link.desktop owncloud-open.desktop /usr/share/applications
-	cp -p owncloud-copy-link.desktop owncloud-copy-link-kde.desktop /usr/share/applications/kde4
+	cp -p owncloud-copy-link-kde.desktop /usr/share/applications/kde4
 	install -t /usr/local/bin owncloud_transform.py owncloud_copy_link owncloud_open
 	install -t /usr/share/nautilus-python/extensions/ filemanager-integration/nautilus_copy_link.py
 	update-desktop-database

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 install: /usr/bin/xclip /usr/share/nautilus-python
 	cp -p owncloud-copy-link.desktop owncloud-open.desktop /usr/share/applications
+	cp -p owncloud-copy-link.desktop owncloud-copy-link-kde.desktop /usr/share/applications/kde4
 	install -t /usr/local/bin owncloud_transform.py owncloud_copy_link owncloud_open
 	install -t /usr/share/nautilus-python/extensions/ filemanager-integration/nautilus_copy_link.py
 	update-desktop-database
@@ -11,7 +12,7 @@ install: /usr/bin/xclip /usr/share/nautilus-python
 	if which apt-get; then apt-get install xclip; else echo "please install xclip!"; fi
 
 uninstall:
-	rm -f /usr/share/applications/owncloud-copy-link.desktop /usr/share/applications/owncloud-open.desktop
+	rm -f /usr/share/applications/owncloud-copy-link.desktop /usr/share/applications/owncloud-open.desktop /usr/share/applications/kde4/owncloud-copy-link-kde.desktop
 	rm -f /usr/local/bin/owncloud_transform.py /usr/local/bin/owncloud_copy_link /usr/local/bin/owncloud_open
 	rm -f /usr/share/nautilus-python/extensions/nautilus_copy_link.py
 	update-desktop-database

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ This is a (non-standard) ownCloud URL handler implementation. It contains three 
 
 * **Nautilus**: The Nautilus extension adds a "Copy ownCloud Link" entry to the context ("right click") menu, which runs `owncloud_copy_link` with the selected file as a parameter. The extension requires Nautilus-Python support (may be called called `nautilus-python` or `python-nautilus`).
 
+* **Dolphin**: The Dolphin extension adds a "Copy ownCloud Link" entry to the "Actions" context ("right click") menu, which runs `owncloud_copy_link` with the selected file as a parameter. TODO: Probably depends on package *python-kde4*.
+
 ## Installation
 
-This will install the utilities in `/usr/local/bin`, the .desktop files in `/usr/share/applications` and the Nautilus extension in `/usr/share/nautilus-python/extensions`.
+This will install the utilities in `/usr/local/bin`, the .desktop files in `/usr/share/applications`, `/usr/share/applications/kde4` and the Nautilus extension in `/usr/share/nautilus-python/extensions`.
 
 ```
 sudo make install 
@@ -30,7 +32,7 @@ To install the .xpi, just open it in Firefox.
   
 ## State
 
-Currently tested (a little) on Ubuntu 14.04 with XFCE. Should work on Linux in general. Some issues may still arise (perhaps with custom ownCloud client configurations), in which case please report them. Mac / Windows support is still missing.
+Currently tested (a little) on Ubuntu 14.04 with XFCE and Ubuntu 12.04 with KDE. Should work on Linux in general. Some issues may still arise (perhaps with custom ownCloud client configurations), in which case please report them. Mac / Windows support is still missing.
 
 ## License
 

--- a/owncloud-copy-link-kde.desktop
+++ b/owncloud-copy-link-kde.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Service
+X-KDE-ServiceTypes=KonqPopupMenu/Plugin
+MimeType=inode/directory;application/octet-stream;
+Actions=owncloudLink;
+X-KDE-AuthorizeAction=shell_access
+
+[Desktop Action owncloudLink]
+Exec=owncloud_copy_link %u
+Icon=owncloud
+Name=Copy ownCloud link


### PR DESCRIPTION
I added the copy link feature to KDE/Dolphin according to https://techbase.kde.org/Development/Tutorials/Creating_Konqueror_Service_Menus.
I'm not happy with the file naming (owncloud-copy-link-kde.desktop), but didn't have a better idea how to fit it into the existing file structure. Please rename if you have a better idea.
